### PR TITLE
Dexsearch in LC, rotom mow vs glow typo

### DIFF
--- a/data/learnsets.ts
+++ b/data/learnsets.ts
@@ -51214,7 +51214,7 @@ export const Learnsets: {[speciesid: string]: LearnsetData} = {
 			leafstorm: ["8L1", "7R", "6R", "5R", "4R"],
 		},
 	},
-	rotommow: {
+	rotomglow: {
 		learnset: {
 			photondischarge: ["8L1", "7R", "6R", "5R", "4R"],
 		},

--- a/server/chat-plugins/datasearch.ts
+++ b/server/chat-plugins/datasearch.ts
@@ -483,7 +483,7 @@ function runDexsearch(target: string, cmd: string, canAll: boolean, message: str
 		nubl: 'NUBL', nu: 'NU',
 		publ: 'PUBL', pu: 'PU', zu: '(PU)',
 		nfe: 'NFE',
-		lc: 'LC',
+		lc: 'LC', lcuber: "LC UBERS", lcou: "LC OU", lcuu: "LC UU",
 		cap: 'CAP', caplc: 'CAP LC', capnfe: 'CAP NFE',
 	});
 	const allDoublesTiers: {[k: string]: TierTypes.Singles | TierTypes.Other} = Object.assign(Object.create(null), {


### PR DESCRIPTION
Feature expansion requested by Ataki: ability to search by LC tiers, and not just all of LC. 
Also included is fix to the bug that rotom mow has photon discharge instead of leaf storm, and rotom glow not having photon discharge